### PR TITLE
Fixes #53 - Automatically run npm install on make install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,9 @@ install: docker-build
 	docker start tc39-website
 	docker exec -ti tc39-website bundle install
 	docker stop tc39-website
+	@if command -v npm; then\
+		npm install;\
+	fi
 
 build:
 	docker start tc39-website


### PR DESCRIPTION
This will enable linting on a contributor's environment from the very beginning.

@codehag 