### PR TITLE
fix: always use absolute URLs for assets, including protocols

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,11 +8,11 @@
     <link rel="icon" type="image/png" href="favicon-32x32.png" sizes="32x32" />
     <link rel="icon" type="image/png" href="favicon-16x16.png" sizes="16x16" />
     <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,600|Source+Sans+Pro:300,400,600" rel="stylesheet">
-    <link rel="stylesheet" href="/assets/css/normalize.css">
-    <link rel="stylesheet" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
-    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/default.min.css">
-    <script defer src="{{ '/assets/js/main.js?v=' | append: site.github.build_revision | relative_url }}" type="text/javascript"></script>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js" type="text/javascript"></script>
+    <link rel="stylesheet" href="{{ site.github.url }}/assets/css/normalize.css">
+    <link rel="stylesheet" href="{{ site.github.url }}{{ '/assets/css/style.css?v=' | append: site.github.build_revision }}">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/default.min.css">
+    <script defer src="{{ site.github.url }}{{ '/assets/js/main.js?v=' | append: site.github.build_revision }}" type="text/javascript"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js" type="text/javascript"></script>
     <script>hljs.initHighlightingOnLoad();</script>
   </head>
   <body class="no-js">


### PR DESCRIPTION
Fixes #64 

> You can make them absolute which tends to make development across forks/repos easier:

> ```html
> <link href="{{site.github.url}}/css/....">
> ```

> Locally site.github.url is just ''. When served through gh-pages it'll be https://tc39.github.io/beta, and when forked to e.g. me it'll be https://keithamus.github.io/beta

> Also while on the topic of URLs - it is preferred to avoid protocol relative URLs (that is, urls without the http, e.g. src="//cdnjs.cloudflare.com...". This should be avoided because if you have an https capable asset, it should ideally always be served with https. (See https://www.paulirish.com/2010/the-protocol-relative-url/)