### PR TITLE
Fix #68 Move popup to outside of the window when closing it

### DIFF
--- a/_sass/_popup.scss
+++ b/_sass/_popup.scss
@@ -3,40 +3,40 @@
   left: 0;
   position: fixed;
   width: 100%;
-}
 
-input[type="checkbox"] + label {
-  position: absolute;
-  transition: 
-    opacity 0.3s ease-in-out,
-    transform 0.6s ease-in-out;
-  will-change: opacity, transform;
-}
+  input[type="checkbox"] + label {
+    position: absolute;
+    transition: 
+      opacity 0.3s ease-in-out,
+      transform 0.6s ease-in-out;
+    will-change: opacity, transform;
+  }
 
-input[type="checkbox"]:checked + label {
-  opacity: 0;
-  transform: translateY(100%);
-}
+  input[type="checkbox"]:checked + label {
+    opacity: 0;
+    transform: translateY(100%);
+  }
 
-.close {
-  color: #b94b45;
-  cursor: pointer;
-  float: right;
-}
+  .close {
+    color: #b94b45;
+    cursor: pointer;
+    float: right;
+  }
 
-.alert-message {
-  background: black;
-  background-color: black;
-  border: 1px solid rgba(#34495e, 0.25);
-  border-radius: 3px;
-  bottom: 0;
-  box-shadow: 0 10px 50px rgba(0,0,0,.6);
-  box-sizing: border-box;
-  color: #b94b45;
-  color: rgba(255, 255, 255, .9);
-  display: block; left: 0;
-  line-height: 30px;
-  padding: 20px 44px;
-  position: absolute;
-  width: 100%;
+  .alert-message {
+    background: black;
+    background-color: black;
+    border: 1px solid rgba(#34495e, 0.25);
+    border-radius: 3px;
+    bottom: 0;
+    box-shadow: 0 10px 50px rgba(0,0,0,.6);
+    box-sizing: border-box;
+    color: #fff;
+    color: rgba(255, 255, 255, .9);
+    display: block; left: 0;
+    line-height: 30px;
+    padding: 20px 44px;
+    position: absolute;
+    width: 100%;
+  }
 }

--- a/_sass/_popup.scss
+++ b/_sass/_popup.scss
@@ -6,7 +6,7 @@
 }
 
 input[type="checkbox"] + label {
-  position:relative;
+  position: absolute;
 }
 
 input[type="checkbox"]:checked + label {
@@ -26,6 +26,7 @@ input[type="checkbox"]:checked + label {
   background-color: black;
   border: 1px solid rgba(#34495e, 0.25);
   border-radius: 3px;
+  bottom: 0;
   box-shadow: 0 10px 50px rgba(0,0,0,.6);
   box-sizing: border-box;
   color: #b94b45;
@@ -34,7 +35,6 @@ input[type="checkbox"]:checked + label {
   line-height: 30px;
   padding: 20px 44px;
   position: absolute;
-  top: 0;
   width: 100%;
 }
 
@@ -49,11 +49,11 @@ input[type="checkbox"]:checked + label {
 
 @keyframes moving {
   0%, 90% {
+    bottom: 0;
     left: 0;
-    top: 0;
   }
   100%  {
+    bottom: -100px;
     left: 0;
-    top: -100px;
   }
 }

--- a/_sass/_popup.scss
+++ b/_sass/_popup.scss
@@ -7,18 +7,21 @@
 
 input[type="checkbox"] + label {
   position: absolute;
+  transition: 
+    opacity 0.3s ease-in-out,
+    transform 0.6s ease-in-out;
+  will-change: opacity, transform;
 }
 
 input[type="checkbox"]:checked + label {
-  animation:
-    closing 0.3s forwards ease-in-out,
-    moving 0.3s forwards ease-in-out;
+  opacity: 0;
+  transform: translateY(100%);
 }
 
 .close {
   color: #b94b45;
-  cursor: hand;
-  float:right;
+  cursor: pointer;
+  float: right;
 }
 
 .alert-message {
@@ -36,24 +39,4 @@ input[type="checkbox"]:checked + label {
   padding: 20px 44px;
   position: absolute;
   width: 100%;
-}
-
-@keyframes closing {
-  from {
-    opacity: 1;
-  }
-  to {
-    opacity: 0;
-  }
-}
-
-@keyframes moving {
-  0%, 90% {
-    bottom: 0;
-    left: 0;
-  }
-  100%  {
-    bottom: -100px;
-    left: 0;
-  }
 }


### PR DESCRIPTION
This PR make sure the popup not cover any content of the page when it is closed by move it to outside of the window.