### PR TITLE
Organises _variables.scss to be more readable

### DIFF
--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -1,14 +1,21 @@
+// Colors
 $color-tc39: #f90;
 $color-primary: #7cb;
-$color-bg: #fefefe;
-$color-spacer: #eee;
 $color-text: #000;
 $color-nav: #444;
+$color-spacer: #eee;
 $color-submenu-bg: #fcfcfc;
+$color-bg: #fefefe;
+
+// Font weights
 $font-weight-light: 300;
 $font-weight-regular: 400;
 $font-weight-semi-bold: 550;
+
+// Spacing
 $grid-gutter: 40px;
 $spacing-paragraph: 40px;
+
+// Breakpoints
 $bp-tablet: 920px;
 $bp-desktop: 1200px;


### PR DESCRIPTION
In order to make _variables.scss more readable it might help to:
- separate items by an empty line
- add headers for easy visual navigation
- order items by their color value (first colors, then grey values ascending)

This pr is an idea of how this might look for the file.