### PR TITLE
Update links to Recent Notes and Upcoming Agenda

### DIFF
--- a/_layouts/menu.html
+++ b/_layouts/menu.html
@@ -9,10 +9,10 @@
     </button>
     <ul class="submenu">
       <li class="submenu-item">
-        <a class="menu-link" href="https://github.com/tc39/agendas/blob/master/2018/07.md">Upcoming Agenda</a>
+        <a class="menu-link" href="https://github.com/tc39/agendas/blob/master/2019/01.md">Upcoming Agenda</a>
       </li>
       <li class="submenu-item">
-        <a class="menu-link" href="https://github.com/tc39/tc39-notes/blob/master/es9/2018-05/toc.md">Recent Meeting Notes</a>
+        <a class="menu-link" href="https://github.com/tc39/tc39-notes/blob/master/es9/2018-11/summary.md">Recent Meeting Notes</a>
       </li>
     </ul>
   </li>


### PR DESCRIPTION
There should be a better way to do this (https://github.com/tc39/beta/issues/91), just updated links manually for now