### PR TITLE
fix: normalize.css 404

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,7 +8,7 @@
     <link rel="icon" type="image/png" href="favicon-32x32.png" sizes="32x32" />
     <link rel="icon" type="image/png" href="favicon-16x16.png" sizes="16x16" />
     <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,600|Source+Sans+Pro:300,400,600" rel="stylesheet">
-    <link rel="stylesheet" href="/assets/css/normalize.css">
+    <link rel="stylesheet" href="{{ '/assets/css/normalize.css' | relative_url }}">
     <link rel="stylesheet" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/default.min.css">
     <script defer src="{{ '/assets/js/main.js?v=' | append: site.github.build_revision | relative_url }}" type="text/javascript"></script>
@@ -43,4 +43,3 @@
     <img src="https://d3nrsflo8ae6b5.cloudfront.net/1x1.png" alt="pixel" />
   </body>
 </html>
-


### PR DESCRIPTION
https://tc39.github.io/beta

<img width="478" alt="screen shot 2019-02-07 at 13 16 06" src="https://user-images.githubusercontent.com/464300/52411045-ad492580-2ada-11e9-97d5-46bb78075b8b.png">

The request URL should be: [`https://tc39.github.io/beta/assets/css/normalize.css`](https://tc39.github.io/beta/assets/css/normalize.css)