### PR TITLE
Ensure that feature list tags don't wrap when screen width is just above 920px.

### DIFF
--- a/_includes/proposals.html
+++ b/_includes/proposals.html
@@ -41,7 +41,7 @@
             <h4 class="featurelist__item__title flex-grow">
               <a href="https://github.com/tc39/{{ proposal.id }}">{{ proposal.title }}</a>
             </h4>
-            <section class="featurelist__item__tags flex-shrink" tabindex="-1">
+            <section class="featurelist__item__tags" tabindex="-1">
               <ul class="featurelist__item__status featurelist__item__tags">
                 {% if proposal.presented | size %}
                 {% for presentation in proposal.presented %}

--- a/_sass/_featurelist.scss
+++ b/_sass/_featurelist.scss
@@ -10,10 +10,8 @@
       overflow: hidden;
       transition: max-height 600ms ease;
     }
-    &__ressources {
-      a {
-        word-break: break-all;
-      }
+    &__tags {
+      flex-shrink: 0;
     }
     &__tag {
       display: inline-block;
@@ -29,9 +27,6 @@
         color: white;
         text-decoration: none;
         word-break: break-all;
-      }
-      p {
-        margin: 0;
       }
     }
     &__status {
@@ -87,16 +82,6 @@
       &:hover {
         a {
           color: $tag-presented;
-        }
-      }
-    }
-    &__impl {
-      background-color: $tag-presented;
-      border: 2px solid $tag-presented;
-      border-radius: 10px;
-      &:hover {
-        a {
-          color: $tag-tests;
         }
       }
     }


### PR DESCRIPTION
Resolves #131.