### PR TITLE
Fix Scrollbar

### DIFF
--- a/_sass/_page-menu.scss
+++ b/_sass/_page-menu.scss
@@ -74,7 +74,7 @@ $trans-timing: 600ms;
     right: 0;
     top: 0;
     transition: max-height $trans-timing ease;
-    width: 100vw;
+    width: 100%;
     z-index: 2;
     [dir="rtl"] & {
       padding: ($svg-height + $mobile-mt) 0 10px 20px;


### PR DESCRIPTION
## Problem

- When the window is too narrow, a scrollbar appears

![image](https://user-images.githubusercontent.com/16232537/54562359-22a3f200-49c7-11e9-812a-18cdf2780cd8.png)
- Pictured: Chrome right, Firefox left (current dev versions)


## Solution

The problem is the width of the .menu pane `100vh` and the additional padding on the right (20px) which lets the element overflow. 
 
- Either change width: 100vw to 100% (in this pr) 
- Or remove the line altogether (as right 0, left 0 negates that anyways)
- Or change to the width to calc(100vw - 20px) because of the padding.

## Solution Pictured

![image](https://user-images.githubusercontent.com/16232537/54563045-84b12700-49c8-11e9-81ec-03bcd9e76063.png)
- no scrollbars anymore


