### PR TITLE
TC39 orange tweaked to 4.5:1 contrast ratio on white.

### DIFF
--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -1,5 +1,6 @@
 // Colors
 $color-tc39: #f90;
+$color-tc39-a11y: #AB6700;
 $color-primary: #017e78;
 $color-link: #017e78;
 $color-text: #000;

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -1,6 +1,6 @@
 // Colors
 $color-tc39: #f90;
-$color-tc39-a11y: #AB6700;
+$color-tc39-dark: #AB6700;
 $color-primary: #017e78;
 $color-link: #017e78;
 $color-text: #000;
@@ -24,5 +24,5 @@ $bp-desktop: 1200px;
 
 // Tags
 $tag-tests: #017e78;
-$tag-spec: #f90;
+$tag-spec: #AB6700;
 $tag-presented: #a63446;


### PR DESCRIPTION
This is part of a couple changes to make the orange tags meet WCAG 2.1 contrast requirements per issue #139 .