### PR TITLE
Duplicated hover styles to focus

### DIFF
--- a/_sass/_featurelist.scss
+++ b/_sass/_featurelist.scss
@@ -23,6 +23,9 @@
       &:hover {
         background-color: transparent;
       }
+      &:focus-within {
+        background-color: transparent;
+      }
       a {
         color: white;
         text-decoration: none;
@@ -56,6 +59,11 @@
       background-color: $tag-tests;
       border: 2px solid $tag-tests;
       border-radius: 10px;
+      &:focus-within {
+        a {
+          color: $tag-tests;
+        }
+      }
       &:hover {
         a {
           color: $tag-tests;
@@ -66,6 +74,11 @@
       background-color: $tag-spec;
       border: 2px solid $tag-spec;
       border-radius: 10px;
+      &:focus-within {
+        a {
+          color: $tag-spec;
+        }
+      }
       &:hover {
         a {
           color: $tag-spec;
@@ -76,6 +89,11 @@
       background-color: $tag-presented;
       border: 2px solid $tag-presented;
       border-radius: 10px;
+      &:focus-within {
+        a {
+          color: $tag-presented;
+        }
+      }
       &:hover {
         a {
           color: $tag-presented;


### PR DESCRIPTION
This supports keyboard-only users by replicating the hover states as focus styles. The catch is that the hover states are on the container _and_ the interactive control, necessitating `:focus-within`. Because this selector will kill an entire style for IE users when added into another selector, it warrants its own stand-alone selector (and still leaves IE users unsupported for focus styles, so there is still a gap). Also, I do not know SASS (woo!).