### PR TITLE
Move 'details' pointer cursor to only summary

### DIFF
--- a/_sass/_featurelist.scss
+++ b/_sass/_featurelist.scss
@@ -171,6 +171,6 @@
     text-align: center;
   }
 }
-details {
+details summary {
   cursor: pointer;
 }


### PR DESCRIPTION
Do not show a `pointer` cursor for the entire `details` element, only the `summary`. The current behavior is misleading, since clicking on other parts of `details` (apart from the badges) does not close the `details`.