### PR TITLE
Clicking the example tag bubbles should not have an effect.

### DIFF
--- a/_includes/proposals.html
+++ b/_includes/proposals.html
@@ -18,17 +18,17 @@
       <ul class="featurelist__legend__tags">
           <li>Last Presented:
             <div class="featurelist__item__presented featurelist__item__tag">
-              <a href="#" title="Notes from most recent presentation">December 2018</a>
+              <a title="Notes from most recent presentation">December 2018</a>
             </div>
           </li>
           <li>Available Tests:
             <div class="featurelist__item__tests featurelist__item__tag">
-              <a href="#" title="Patch introducing tests in test262 repository">Test</a>
+              <a title="Patch introducing tests in test262 repository">Test</a>
             </div>
           </li>
           <li>Specification Text:
             <div class="featurelist__item__spec featurelist__item__tag">
-              <a href="#" title="Read the specification text">Specification</a>
+              <a title="Read the specification text">Specification</a>
             </div>
           </li>
       </ul>


### PR DESCRIPTION
Noticed this via #150—this might not be the only possible fix but we definitely don't want `href="#"`.