### PR TITLE
fix #159, remove automatic git hooks. CI lint js

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ If changes in the upstream master branch cause your PR to have conflicts, you sh
 rebase your branch to master and force-push it to your repo (rather than doing a
 merge commit).
 
+### Code style
+
+The repo contains a [prettier](https://prettier.io/) and [stylelint](https://stylelint.io/) configuration.
+Code style is checked via CI. To prevent unnecessary red builds you should check locally before committing via `npm run lint`.
+
 ## Local development
 
 Building the website requires [Docker](https://docs.docker.com/install/). This gives you a dev environment with Ruby, Bundler, and all other project dependencies already installed.

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,103 +1,115 @@
-'use strict';
+"use strict";
 
 function openMenu(menu) {
-  menu.style.maxHeight = menu.scrollHeight + 'px';
+  menu.style.maxHeight = menu.scrollHeight + "px";
   setTimeout(function() {
-    menu.style.maxHeight = 'none';
+    menu.style.maxHeight = "none";
   }, 600);
 }
 
 function closeMenu(menu) {
-  menu.style.maxHeight = menu.scrollHeight + 'px';
+  menu.style.maxHeight = menu.scrollHeight + "px";
   setTimeout(function() {
-    menu.style.maxHeight = '';
+    menu.style.maxHeight = "";
   }, 0);
 }
 
 function toggleMenu(menu) {
-  menu = menu || document.querySelector('#menu');
+  menu = menu || document.querySelector("#menu");
   var maxHeight = menu.style.maxHeight;
   !!maxHeight ? closeMenu(menu) : openMenu(menu);
-  menu.classList.toggle('open');
+  menu.classList.toggle("open");
 }
 
 function toggleProposal(item) {
-  var content = item.querySelector('.featurelist__item__info');
+  var content = item.querySelector(".featurelist__item__info");
   var maxHeight = content.style.maxHeight;
-  content.style.maxHeight = !!maxHeight ? '' : content.scrollHeight + 'px';
-  content.setAttribute('aria-hidden', !!maxHeight);
+  content.style.maxHeight = !!maxHeight ? "" : content.scrollHeight + "px";
+  content.setAttribute("aria-hidden", !!maxHeight);
   if (!!maxHeight) {
-    content.setAttribute('tabindex', '-1');
+    content.setAttribute("tabindex", "-1");
   } else {
-    content.removeAttribute('tabindex');
+    content.removeAttribute("tabindex");
   }
-  item.classList.toggle('open');
+  item.classList.toggle("open");
 }
 
 /**
  * Represents the start of this application
  */
 function start() {
-  var items = document.querySelectorAll('.featurelist__item .featurelist__item__example');
+  var items = document.querySelectorAll(
+    ".featurelist__item .featurelist__item__example"
+  );
 
-  document.body.classList.remove('no-js');
+  document.body.classList.remove("no-js");
 
-  items.forEach(function (v) {
-    v.addEventListener('click', function (ev) {
+  items.forEach(function(v) {
+    v.addEventListener("click", function(ev) {
       toggleProposal(this.parentNode);
     });
-    v.addEventListener('keypress', function (ev) {
+    v.addEventListener("keypress", function(ev) {
       if (ev.key === "Enter" || ev.key === " ") {
         ev.preventDefault();
         toggleProposal(this.parentNode);
       }
     });
-    v.addEventListener('keydown', function (ev) {
+    v.addEventListener("keydown", function(ev) {
       var nextItem = ev.target.parentNode.nextElementSibling;
       var prevItem = ev.target.parentNode.previousElementSibling;
-      if (ev.key === "ArrowDown" && nextItem && nextItem.classList.contains('featurelist__item')) {
+      if (
+        ev.key === "ArrowDown" &&
+        nextItem &&
+        nextItem.classList.contains("featurelist__item")
+      ) {
         ev.preventDefault();
         nextItem.firstElementChild.focus();
       }
-      if (ev.key === "ArrowUp" && prevItem && prevItem.classList.contains('featurelist__item')) {
+      if (
+        ev.key === "ArrowUp" &&
+        prevItem &&
+        prevItem.classList.contains("featurelist__item")
+      ) {
         ev.preventDefault();
         prevItem.firstElementChild.focus();
       }
     });
-
   });
 
-  document.querySelector('.menu-toggle').addEventListener('click', function (ev) {
-    ev.preventDefault();
-    toggleMenu();
-  });
+  document
+    .querySelector(".menu-toggle")
+    .addEventListener("click", function(ev) {
+      ev.preventDefault();
+      toggleMenu();
+    });
 
-  document.querySelectorAll('.menu-link').forEach(function (link) {
-    link.addEventListener('click', function (ev) {
-      if (ev.target.href.startsWith('#')) {
+  document.querySelectorAll(".menu-link").forEach(function(link) {
+    link.addEventListener("click", function(ev) {
+      if (ev.target.href.startsWith("#")) {
         ev.preventDefault();
         toggleMenu();
-        var target = document.querySelector(ev.target.getAttribute('href'));
+        var target = document.querySelector(ev.target.getAttribute("href"));
         window.scrollTo({
-          behavior: 'smooth',
-          top: Math.floor(target.getBoundingClientRect().top + document.body.scrollTop)
+          behavior: "smooth",
+          top: Math.floor(
+            target.getBoundingClientRect().top + document.body.scrollTop
+          )
         });
-        setTimeout(function () {
+        setTimeout(function() {
           target.focus();
         }, 400);
       }
     });
   });
 
-  document.querySelectorAll('.submenu-toggle').forEach(function (toggle) {
-    toggle.addEventListener('click', function (ev) {
+  document.querySelectorAll(".submenu-toggle").forEach(function(toggle) {
+    toggle.addEventListener("click", function(ev) {
       var t = ev.target;
-      var submenu = t.parentNode.querySelector('.submenu');
+      var submenu = t.parentNode.querySelector(".submenu");
       toggleMenu(submenu);
-      t.classList.toggle('open');
+      t.classList.toggle("open");
     });
   });
-
 }
 
 start();

--- a/package.json
+++ b/package.json
@@ -4,19 +4,10 @@
   "description": "Draft for TC39 website",
   "main": "index.js",
   "scripts": {
-    "lint": "stylelint _sass",
+    "lint": "npm run lint:js && npm run lint:scss",
+    "lint:js": "prettier -c --loglevel warn **/*.js",
+    "lint:scss": "stylelint _sass",
     "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged"
-    }
-  },
-  "lint-staged": {
-    "*.scss": [
-      "stylelint --fix",
-      "git add"
-    ]
   },
   "repository": {
     "type": "git",
@@ -29,8 +20,6 @@
   },
   "homepage": "https://tc39.github.io",
   "devDependencies": {
-    "husky": "^2.3.0",
-    "lint-staged": "^8.1.7",
     "prettier": "^1.17.1",
     "stylelint": "^10.0.1",
     "stylelint-config-prettier": "^5.2.0",


### PR DESCRIPTION
Fixes #159.

Drops git hooks (husky & lint-staged) and extends `npm lint` by also running prettier.