### PR TITLE
fix #156, improve keyboard navigation

### DIFF
--- a/_includes/contribute.html
+++ b/_includes/contribute.html
@@ -1,7 +1,6 @@
 <section>
-  <a id="contribute" tabindex="-1"></a>
   <div class="g-row">
-    <h2 class="section-headline g-col-4">Contribute</h2>
+    <h2 id="contribute" class="section-headline g-col-4">Contribute</h2>
     <div class="g-col-8">
       <p>
         TC39 welcomes contributions from the JavaScript community, whether it is feedback on existing proposals, improved documentation,

--- a/_includes/proposals.html
+++ b/_includes/proposals.html
@@ -1,6 +1,5 @@
-<section>
-  <a id="proposals" tabindex="-1"></a>
-  <h2 class="section-headline text-end">State of Proposals</h2>
+<article>
+  <h2 id="proposals" class="section-headline text-end">State of Proposals</h2>
   <div class="featurelist">
     <h3>Current Candidates for the Specification</h3>
     <i class="featurelist__desc">
@@ -34,14 +33,13 @@
       </ul>
     </details>
     {% for proposal in site.data.stage3 %}
-    <section class="featurelist__item">
-      <section class="">
-        <header class="featurelist__item__intro" tabindex="0">
-          <section class="g-row">
+      <article class="featurelist__item">
+        <div class="featurelist__item__intro">
+          <header class="g-row">
             <h4 class="featurelist__item__title flex-grow">
               <a href="https://github.com/tc39/{{ proposal.id }}">{{ proposal.title }}</a>
             </h4>
-            <section class="featurelist__item__tags" tabindex="-1">
+            <div class="featurelist__item__tags">
               <ul class="featurelist__item__status featurelist__item__tags">
                 {% if proposal.presented | size %}
                 {% for presentation in proposal.presented %}
@@ -63,50 +61,64 @@
                   </li>
                 {% endif %}
               </ul>
-            </section>
-          </section>
-          <section class="featurelist__item__author">
-          {% if proposal.authors == proposal.champions %}
-            Author and Champion:
-            {{ proposal.authors | join: ", " }}
-          {% else %}
-            {% if proposal.authors | size %}
-            {% if proposal.authors.size > 1 %}
-            Authors:
-            {% else %}
-            Author:
-            {% endif %}
-            {{ proposal.authors | join: ", " }}
-            {% endif %}
-            {% if proposal.champions | size %}
-            |
-            {% if proposal.champions.size > 1 %}
-            Champions:
-            {% else %}
-            Champion:
-            {% endif %}
-            {{ proposal.champions | join: ", " }}
-            {% endif %}
-          {% endif %}
-          </section>
-          {% if proposal.description %}
-          <section class="featurelist__item__desc">{{ proposal.description }}</section>
-          {% endif %}
-        {% if proposal.example %}
-          <div class="featurelist__item__example">Show Example</div>
-        {% endif %}
-        <section class="featurelist__item__info" tabindex="-1">
-        {% if proposal.example %}
-          <div>
-            <div>
-              <pre><code class="js">{{ proposal.example }}</code></pre>
             </div>
+          </header>
+          <div class="featurelist__item__author">
+            {% if proposal.authors == proposal.champions %}
+              Author and Champion:
+              {{ proposal.authors | join: ", " }}
+            {% else %}
+              {% if proposal.authors | size %}
+              {% if proposal.authors.size > 1 %}
+              Authors:
+              {% else %}
+              Author:
+              {% endif %}
+              {{ proposal.authors | join: ", " }}
+              {% endif %}
+              {% if proposal.champions | size %}
+              |
+              {% if proposal.champions.size > 1 %}
+              Champions:
+              {% else %}
+              Champion:
+              {% endif %}
+              {{ proposal.champions | join: ", " }}
+              {% endif %}
+            {% endif %}
           </div>
-        {% endif %}
+          {% if proposal.description %}
+          <div class="featurelist__item__desc">{{ proposal.description }}</div>
+          {% endif %}
+          {% if proposal.example %}
+          <div
+            class="featurelist__item__example"
+            aria-controls="example-{{ proposal.id }}"
+            aria-expanded="false"
+            tabindex="0"
+            id="example-toggle-{{ proposal.id }}"
+            aria-selected="false"
+          >
+            Show Example
+          </div>
+          {% endif %}
+          <section
+            class="featurelist__item__info"
+            id="example-{{ proposal.id }}"
+            role="region"
+            aria-hidden="true"
+            aria-labelledby="example-toggle-{{ proposal.id }}"
+          >
+            {% if proposal.example %}
+              <div>
+                <div>
+                  <pre><code class="js" tabindex="-1">{{ proposal.example }}</code></pre>
+                </div>
+              </div>
+            {% endif %}
+          </div>
         </section>
-        </header>
-      </section>
-    </section>
+      </article>
     {% endfor %}
   </div>
   <section class="featurelist__more">

--- a/_includes/specs.html
+++ b/_includes/specs.html
@@ -1,7 +1,6 @@
 <section>
-  <a id="specs" tabindex="-1"></a>
   <div class="g-row">
-    <h2 class="section-headline g-col-4">The Specs</h2>
+    <h2 id="specs" class="section-headline g-col-4">The Specs</h2>
     <div class="g-col-8">
       <p>
         We develop the JavaScript (formally, ECMAScript) specification

--- a/_includes/tc39.html
+++ b/_includes/tc39.html
@@ -1,7 +1,6 @@
 <section>
-  <a id="tc39" tabindex="-1"></a>
   <div class="g-row">
-    <h2 class="section-headline g-col-4">About the TC39</h2>
+    <h2 id="tc39" class="section-headline g-col-4">About the TC39</h2>
     <div class="g-col-8">
       <p>
         TC39 is a group of JavaScript developers, implementers, academics, and more, collaborating with the community to maintain

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -18,7 +18,7 @@
   <body class="no-js">
     <main class="main">
     {% include_relative _layouts/page_header.html %}
-    <h1 class="page-title">Specifying JavaScript.</h1>
+    <h1 id="content" class="page-title">Specifying JavaScript.</h1>
     <section class="main-content">
       {% include intro.html %}
       {% include proposals.html %}

--- a/_layouts/menu.html
+++ b/_layouts/menu.html
@@ -1,4 +1,5 @@
-<a href="#menu" class="menu-toggle">
+<a href="#content" class="skip-menu">Skip to content</a>
+<a href="#menu" class="menu-toggle" tabindex="-1">
   <span class="menu-toggle-text">Open menu</span>
 </a>
 <ul class="menu" id="menu">

--- a/_sass/_page-menu.scss
+++ b/_sass/_page-menu.scss
@@ -8,6 +8,17 @@ $trans-timing: 600ms;
   transform: rotateX(180deg);
 }
 
+.skip-menu {
+  opacity: 0;
+  position: absolute;
+  right: 84px;
+  top: 10px;
+  z-index: 10;
+  &:focus {
+    opacity: 1;
+  }
+}
+
 .page-menu {
   $mobile-mt: 15px;
   font-size: 18px;

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -54,26 +54,6 @@ function start() {
         toggleProposal(this.parentNode);
       }
     });
-    v.addEventListener("keydown", function(ev) {
-      var nextItem = ev.target.parentNode.nextElementSibling;
-      var prevItem = ev.target.parentNode.previousElementSibling;
-      if (
-        ev.key === "ArrowDown" &&
-        nextItem &&
-        nextItem.classList.contains("featurelist__item")
-      ) {
-        ev.preventDefault();
-        nextItem.firstElementChild.focus();
-      }
-      if (
-        ev.key === "ArrowUp" &&
-        prevItem &&
-        prevItem.classList.contains("featurelist__item")
-      ) {
-        ev.preventDefault();
-        prevItem.firstElementChild.focus();
-      }
-    });
   });
 
   document


### PR DESCRIPTION
Fixes #156.

:warning: Includes #158. Relevant changes are in 7164692 

### Notes

I removed some old JavaScript logic, which related to an older state where proposals were listed in an accordion like manner. Because the visual representation of the proposals changed, I removed this code.

I also restructured the proposals HTML: previously there were a lot of unnecessary nested `section` elements rendered. I think every proposal can be treated as an `article` instead with a `section` for the example.

I also added a `Skip to content` link, to allow to skip the navigation.

This is no necessarily a 100% solution, but should solve general issues with the page.