### PR TITLE
Uncross the descriptions

### DIFF
--- a/_data/stage3.yml
+++ b/_data/stage3.yml
@@ -474,7 +474,7 @@
 - title: String.prototype.replaceAll
   id: proposal-string-replaceall
   has_specification: true
-  description: introduce String.prototype.replaceAll
+  description: Introduce String.prototype.replaceAll as a way to replace all in a string
   authors:
     - Peter Marshall
     - Jakob Gruber
@@ -492,7 +492,7 @@
 - title: Promise.any
   id: proposal-promise-any
   has_specification: true
-  description: Introduce String.prototype.replaceAll as a way to replace all in a string
+  description: The missing combinator, short-circuits when an input value is fulfilled
   authors:
     - Mathias Bynens
     - Kevin Gibbons


### PR DESCRIPTION
Somehow, the Promise.any proposal ended up with a description that should have been on String.prototype.replaceAll.

This patch rectifies that.