### PR TITLE
Fix #149, Tag title and link should work in entire element

### DIFF
--- a/_sass/_featurelist.scss
+++ b/_sass/_featurelist.scss
@@ -15,21 +15,23 @@
     }
     &__tag {
       display: inline-block;
-      font-size: 0.8rem;
-      margin-top: 0.5rem;
-      opacity: 1;
-      padding-left: 0.5rem;
-      padding-right: 0.5rem;
-      &:hover {
-        background-color: transparent;
-      }
-      &:focus-within {
-        background-color: transparent;
-      }
       a {
         color: white;
+        display: block;
+        font-size: 0.8rem;
+        margin-top: 0.5rem;
+        opacity: 1;
+        padding-left: 0.5rem;
+        padding-right: 0.5rem;
         text-decoration: none;
         word-break: break-all;
+
+        &:hover {
+          background-color: transparent;
+        }
+        &:focus {
+          background-color: transparent;
+        }
       }
     }
     &__status {
@@ -55,49 +57,40 @@
       padding-top: 0;
       word-wrap: anywhere;
     }
-    &__tests {
+    /* stylelint-disable-next-line no-descending-specificity */
+    &__tests a {
       background-color: $tag-tests;
       border: 2px solid $tag-tests;
       border-radius: 10px;
-      &:focus-within {
-        a {
-          color: $tag-tests;
-        }
+      &:focus {
+        color: $tag-tests;
       }
       &:hover {
-        a {
-          color: $tag-tests;
-        }
+        color: $tag-tests;
       }
     }
-    &__spec {
+    /* stylelint-disable-next-line no-descending-specificity */
+    &__spec a {
       background-color: $tag-spec;
       border: 2px solid $tag-spec;
       border-radius: 10px;
-      &:focus-within {
-        a {
-          color: $tag-spec;
-        }
+      &:focus {
+        color: $tag-spec;
       }
       &:hover {
-        a {
-          color: $tag-spec;
-        }
+        color: $tag-spec;
       }
     }
-    &__presented {
+    /* stylelint-disable-next-line no-descending-specificity */
+    &__presented a {
       background-color: $tag-presented;
       border: 2px solid $tag-presented;
       border-radius: 10px;
-      &:focus-within {
-        a {
-          color: $tag-presented;
-        }
+      &:focus {
+        color: $tag-presented;
       }
       &:hover {
-        a {
-          color: $tag-presented;
-        }
+        color: $tag-presented;
       }
     }
     .no-js &:focus-within &__info {


### PR DESCRIPTION
Fix #149. Make the `<a>` display block and move the tag style to the `<a>` element. Which will make the anchor element fill the entire tag. This change solves:

1. The hover tip(title) works in entire tag element, this is issue #149 
2. Click the link works in entire tag element(used to only work when click on the link text)

Not a perfect fix because I have to disable some stylelint rule in certain line. But this change is small. A better solution will have to modify the HTML markup structure. For example, remove the `<li>` element of tag list.