### PR TITLE
fix #147, make element focus more obvious

### DIFF
--- a/_sass/_a11y.scss
+++ b/_sass/_a11y.scss
@@ -7,3 +7,20 @@
   white-space: nowrap;
   width: 1px;
 }
+
+:focus {
+  outline-offset: .125rem;
+  outline-style: solid;
+  outline-width: .125rem;
+}
+
+.logo-box a:focus {
+  outline-color: $color-nav;
+}
+
+.featurelist__item__tag,
+.submenu {
+  :focus {
+    outline: 0;
+  }
+}


### PR DESCRIPTION
Prior to this commit, depending on the browser being used, it may
have been quite difficult to see which element was in focus when
navigating the page using the tab key. This has been corrected by
adjusting the `:focus` pseudo-class styles for selectable elements
so that it no longer depends on inconsistent user-agent styles.

Notes:
    https://user-images.githubusercontent.com/17770407/87440188-b38cdc80-c5bf-11ea-86e3-8b1c8652e25b.png
    https://user-images.githubusercontent.com/17770407/87440518-141c1980-c5c0-11ea-964f-70ff56523438.png

Fixes: https://github.com/tc39/tc39.github.io/issues/147

Aside: Although it may not have been completely obvious, it should
probably be noted that https://github.com/tc39/tc39.github.io/issues/147 may have been mostly addressed in https://github.com/tc39/tc39.github.io/pull/160.