### PR TITLE
account for unpublished notes

### DIFF
--- a/_includes/proposals.html
+++ b/_includes/proposals.html
@@ -59,9 +59,13 @@
         <ul class="featurelist__item__status featurelist__item__tags">
           {% if proposal.presented | size %}
           {% for presentation in proposal.presented %}
-            <li class="featurelist__item__presented featurelist__item__tag">
-              <a href="{{ presentation.url }}" title='{{ site.data["proposals"]["last-presented-alt"] }}'>{{ presentation.date }}</a>
-            </li>
+          <li class="featurelist__item__presented featurelist__item__tag">
+            {%- if presentation.url -%}
+            <a href="{{ presentation.url }}" title='{{ site.data["proposals"]["last-presented-alt"] }}'>{{ presentation.date }}</a>
+            {%- else -%}
+            <span>{{ presentation.date }}</span>
+            {%- endif -%}
+          </li>
           {% endfor %}
           {% endif %}
           {% if proposal.tests | size %}

--- a/_sass/_featurelist.scss
+++ b/_sass/_featurelist.scss
@@ -15,11 +15,11 @@
     }
     &__tag {
       display: inline-block;
+      font-size: 0.8rem;
+
       a {
         color: white;
-        display: block;
-        font-size: 0.8rem;
-        margin-top: 0.5rem;
+        margin-top: 0.5rem;  
         opacity: 1;
         padding-left: 0.5rem;
         padding-right: 0.5rem;
@@ -32,6 +32,17 @@
         &:focus {
           background-color: transparent;
         }
+      }
+
+      span {
+        background-color: $color-dim-gray;
+        border: 2px solid $color-dim-gray;
+        border-radius: 10px;
+        color: white;
+        font-weight: 550;
+        padding-left: 0.5rem;
+        padding-right: 0.5rem;
+        margin-top: 0.5rem;
       }
     }
     &__status {


### PR DESCRIPTION
Modified info crawler algorithm `presenceObject.url` to be optional to account for notes that have yet to be published (non-link emoji). Once the data structure is serialized to YAML, the field will not be present in the data structure.