### PR TITLE
Update contribute-to-proposals link

### DIFF
--- a/_data/de/site.yml
+++ b/_data/de/site.yml
@@ -47,6 +47,6 @@ footer:
 links:
   coc: https://tc39.es/code-of-conduct
   process: https://tc39.es/process-document
-  contribute-to-proposals: https://github.com/tc39/ecma262/blob/master/CONTRIBUTING.md
+  contribute-to-proposals: https://github.com/tc39/ecma262/blob/master/CONTRIBUTING.md#new-feature-proposals
   contribute-to-tests: https://github.com/tc39/test262/blob/master/CONTRIBUTING.md
   discourse: https://es.discourse.group/

--- a/_data/en/site.yml
+++ b/_data/en/site.yml
@@ -46,6 +46,6 @@ footer:
 links:
   coc: https://tc39.es/code-of-conduct
   process: https://tc39.es/process-document
-  contribute-to-proposals: https://github.com/tc39/ecma262/blob/master/CONTRIBUTING.md
+  contribute-to-proposals: https://github.com/tc39/ecma262/blob/master/CONTRIBUTING.md#new-feature-proposals
   contribute-to-tests: https://github.com/tc39/test262/blob/master/CONTRIBUTING.md
   discourse: https://es.discourse.group/

--- a/_data/ja/site.yml
+++ b/_data/ja/site.yml
@@ -46,6 +46,6 @@ footer:
 links:
   coc: https://tc39.es/code-of-conduct
   process: https://tc39.es/process-document
-  contribute-to-proposals: https://github.com/tc39/ecma262/blob/master/CONTRIBUTING.md
+  contribute-to-proposals: https://github.com/tc39/ecma262/blob/master/CONTRIBUTING.md#new-feature-proposals
   contribute-to-tests: https://github.com/tc39/test262/blob/master/CONTRIBUTING.md
   discourse: https://es.discourse.group/

--- a/_data/ru/site.yml
+++ b/_data/ru/site.yml
@@ -47,6 +47,6 @@ footer:
 links:
   coc: https://tc39.es/code-of-conduct
   process: https://tc39.es/process-document
-  contribute-to-proposals: https://github.com/tc39/ecma262/blob/master/CONTRIBUTING.md
+  contribute-to-proposals: https://github.com/tc39/ecma262/blob/master/CONTRIBUTING.md#new-feature-proposals
   contribute-to-tests: https://github.com/tc39/test262/blob/master/CONTRIBUTING.md
   discourse: https://es.discourse.group/

--- a/_data/site.yml
+++ b/_data/site.yml
@@ -33,6 +33,6 @@ footer:
 links:
   coc: https://tc39.es/code-of-conduct
   process: https://tc39.es/process-document
-  contribute-to-proposals: https://github.com/tc39/ecma262/blob/master/CONTRIBUTING.md
+  contribute-to-proposals: https://github.com/tc39/ecma262/blob/master/CONTRIBUTING.md#new-feature-proposals
   contribute-to-tests: https://github.com/tc39/test262/blob/master/CONTRIBUTING.md
   discourse: https://es.discourse.group/

--- a/_data/zh-Hans/site.yml
+++ b/_data/zh-Hans/site.yml
@@ -47,6 +47,6 @@ footer:
 links:
   coc: https://tc39.es/code-of-conduct
   process: https://tc39.es/process-document
-  contribute-to-proposals: https://github.com/tc39/ecma262/blob/master/CONTRIBUTING.md
+  contribute-to-proposals: https://github.com/tc39/ecma262/blob/master/CONTRIBUTING.md#new-feature-proposals
   contribute-to-tests: https://github.com/tc39/test262/blob/master/CONTRIBUTING.md
   discourse: https://es.discourse.group/


### PR DESCRIPTION
The “Contribute to Proposals” links currently lead to a [“Contributing to ECMAScript”](https://github.com/tc39/ecma262/blob/master/CONTRIBUTING.md) that contains information about both contributing directly to Ecma-262 and contributing to new-feature proposals.

This pull request changes these links directly to a [section within this document specifically about contributing to new-feature proposals](https://github.com/tc39/ecma262/blob/master/CONTRIBUTING.md#new-feature-proposals).