### PR TITLE
Add default favicon ico link

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,5 +1,6 @@
 module.exports = function (eleventyConfig) {
   eleventyConfig.addPassthroughCopy('assets');
+  eleventyConfig.addPassthroughCopy('favicon*');
   return {
     dir: {
       input: './', // Equivalent to Jekyll's source property

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,6 +8,7 @@
     />
     <meta name="theme-color" content="#157878" />
     <title>TC39 – {{ site["title"] }}</title>
+    <link rel="icon" type="image/x-icon" href="favicon.ico" />
     <link rel="icon" type="image/png" href="favicon-32x32.png" sizes="32x32" />
     <link rel="icon" type="image/png" href="favicon-16x16.png" sizes="16x16" />
     <link


### PR DESCRIPTION
For my browser, the favicon isn't visible.
We need to include the default ico format too.

<img width="221" alt="Screen Shot 2022-05-07 at 2 11 21 AM" src="https://user-images.githubusercontent.com/15065065/167222606-e3004402-9d54-4026-bf81-908a4ead3e97.png">
