### PR TITLE
add links to all alternate language pages in head

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,6 +8,11 @@
     />
     <meta name="theme-color" content="#157878" />
     <title>TC39 – {{ site["title"] }}</title>
+    <link rel="alternate" hreflang="de" href="https://tc39.es/de/" />
+    <link rel="alternate" hreflang="ja" href="https://tc39.es/ja/" />
+    <link rel="alternate" hreflang="ru" href="https://tc39.es/ru/" />
+    <link rel="alternate" hreflang="zh-Hans" href="https://tc39.es/zh-Hans/" />
+    <link rel="alternate" hreflang="x-default" href="https://tc39.es/" />
     <link rel="icon" type="image/x-icon" href="favicon.ico" />
     <link rel="icon" type="image/png" href="favicon-32x32.png" sizes="32x32" />
     <link rel="icon" type="image/png" href="favicon-16x16.png" sizes="16x16" />


### PR DESCRIPTION
List all current alternate language variants of the page (including
itself) in the `<head>` section, to aid search engines in directing
users to the most appropriate version by language or region.

Refs: https://developers.google.com/search/docs/advanced/crawling/localized-versions#html
Signed-off-by: Derek Lewis <DerekNonGeneric@inf.is>

---

This is not really a fix for #221, but another similarly-related SEO task I discovered had been missing while looking into the structured data recognized by search engines. I could have gone with the alternative way of [specifying this in a sitemap](https://developers.google.com/search/docs/advanced/crawling/localized-versions#sitemap), but am not sure whether one currently exists for these pages or whether doing it that way would make a noticeable difference here.