### PR TITLE
fix(stylelint): re-order presets correctly

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,7 +1,7 @@
 {
   "extends": [
     "stylelint-config-standard-scss",
-    "stylelint-config-prettier-scss",
-    "stylelint-config-recess-order"
+    "stylelint-config-recess-order",
+    "stylelint-config-prettier-scss"
   ]
 }


### PR DESCRIPTION
`stylelint-config-prettier-scss` disables all rules that conflict
with Prettier. Leave this preset at the bottom so that it can't be
overridden.

> Make sure to put it **last**, so it will override other configs.

Refs: https://github.com/prettier/stylelint-config-prettier-scss#installation

Signed-off-by: Derek Lewis <DerekNonGeneric@inf.is>

/cc @smorimoto