### PR TITLE
Fix name of German language

### DIFF
--- a/_data/languages.json
+++ b/_data/languages.json
@@ -4,7 +4,7 @@
     "id": "en"
   },
   {
-    "title": "Sprache",
+    "title": "Deutsch",
     "id": "de"
   },
   {


### PR DESCRIPTION
Currently the German language option is written as "Sprache" instead of "Deutsch". 

Looks like the language selector used to be different for every language, such that the German site used to have a "Sprache" dropdown populated with languages _other_ than German, and this was copied over incorrectly in https://github.com/tc39/tc39.github.io/pull/256.