### PR TITLE
Correct outdated fields in `package.json`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,11 @@
 {
-  "name": "tc39-web-draft",
+  "name": "@tc39/tc39.github.io",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "tc39-web-draft",
-      "version": "0.0.0",
-      "license": "ISC",
+      "name": "@tc39/tc39.github.io",
       "devDependencies": {
         "@11ty/eleventy": "2.0.0",
         "@11ty/eleventy-fetch": "3.0.0",
@@ -23,7 +21,7 @@
         "stylelint-config-standard-scss": "7.0.1"
       },
       "engines": {
-        "node": ">=14.8"
+        "node": ">=18"
       }
     },
     "node_modules/@11ty/dependency-tree": {

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
-  "name": "tc39-web-draft",
-  "private": true,
-  "version": "0.0.0",
-  "description": "Draft for TC39 website",
-  "main": "index.js",
+  "name": "@tc39/tc39.github.io",
+  "description": "Get involved in specifying JavaScript",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tc39/tc39.github.io.git"
+  },
   "scripts": {
     "lint": "npm run lint:js && npm run lint:scss && npm run lint:format",
     "lint:js": "eslint --ext=.js,.mjs .",
@@ -20,19 +21,6 @@
     "prebuild": "npm run sass",
     "start": "npx @11ty/eleventy --serve --watch"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/tc39/tc39.github.io.git"
-  },
-  "author": "",
-  "license": "ISC",
-  "bugs": {
-    "url": "https://github.com/tc39/tc39.github.io/issues"
-  },
-  "homepage": "https://tc39.es/",
-  "engines": {
-    "node": ">=14.8"
-  },
   "devDependencies": {
     "@11ty/eleventy": "2.0.0",
     "@11ty/eleventy-fetch": "3.0.0",
@@ -46,5 +34,9 @@
     "stylelint": "15.2.0",
     "stylelint-config-recess-order": "4.0.0",
     "stylelint-config-standard-scss": "7.0.1"
-  }
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "private": true
 }


### PR DESCRIPTION
This patch corrects all outdated fields in `package.json` based on the npm
official specification.

Signed-off-by: Sora Morimoto <sora@morimoto.io>

<!-- ps-id: 0bd89586-6594-4a9f-ae5d-0f23e1a228c6 -->