### PR TITLE
Bump `engines.node` to `>=20`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "stylelint-config-standard-scss": "11.1.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/@11ty/dependency-tree": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "stylelint-config-standard-scss": "11.1.0"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "private": true
 }


### PR DESCRIPTION
This change minimises my concerns, which I tried to address in #354, in a different way as reasonably and acceptably as possible.