### PR TITLE
Allow favicons to be loaded on non-root paths

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -13,9 +13,9 @@
     <link rel="alternate" hreflang="ru" href="https://tc39.es/ru/" />
     <link rel="alternate" hreflang="zh-Hans" href="https://tc39.es/zh-Hans/" />
     <link rel="alternate" hreflang="x-default" href="https://tc39.es/" />
-    <link rel="icon" type="image/x-icon" href="favicon.ico" />
-    <link rel="icon" type="image/png" href="favicon-32x32.png" sizes="32x32" />
-    <link rel="icon" type="image/png" href="favicon-16x16.png" sizes="16x16" />
+    <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+    <link rel="icon" type="image/png" href="/favicon-32x32.png" sizes="32x32" />
+    <link rel="icon" type="image/png" href="/favicon-16x16.png" sizes="16x16" />
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
@@ -31,7 +31,7 @@
     <link rel="stylesheet" href="{{ '/assets/css/normalize.css' | url }}" />
     <link
       rel="stylesheet"
-      href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | url}}"
+      href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | url }}"
     />
     <script
       defer


### PR DESCRIPTION
| Before | After |
| :-: | :-: |
| <img width="274" alt="image" src="https://github.com/tc39/tc39.github.io/assets/38746192/3ad87c0a-4d43-4bb2-93d9-d38c968da4bd"> | <img width="280" alt="image" src="https://github.com/tc39/tc39.github.io/assets/38746192/e7026bef-bbe2-4024-9588-2027c134e8a3"> |