### PR TITLE
✨ don't link to specific agenda and notes

### DIFF
--- a/_data/site.json
+++ b/_data/site.json
@@ -4,8 +4,8 @@
   "navigation": {
     "TC39": {
       "title": "TC39",
-      "agenda": "Upcoming Agenda",
-      "notes": "Recent Meeting Notes",
+      "agenda": "Meeting Agendas",
+      "notes": "Meeting Notes",
       "sub-menu": "Toggle sub-menu for TC39"
     },
     "specs": {

--- a/_layouts/menu.html
+++ b/_layouts/menu.html
@@ -14,17 +14,14 @@
     </button>
     <ul class="submenu">
       <li class="submenu-item">
-        <a
-          class="menu-link"
-          href="https://github.com/tc39/agendas/blob/main/2023/09.md"
-        >
+        <a class="menu-link" href="https://github.com/tc39/agendas#agendas">
           {{ site["navigation"]["TC39"]["agenda"] }}
         </a>
       </li>
       <li class="submenu-item">
         <a
           class="menu-link"
-          href="https://github.com/tc39/notes/tree/main/meetings/2023-07"
+          href="https://github.com/tc39/notes#tc39-meeting-notes"
         >
           {{ site["navigation"]["TC39"]["notes"] }}
         </a>

--- a/de/site.json
+++ b/de/site.json
@@ -4,8 +4,8 @@
   "navigation": {
     "TC39": {
       "title": "TC39",
-      "agenda": "Bevorstehende Agenda",
-      "notes": "Notizen der letzten Sitzung",
+      "agenda": "Meeting Agendas",
+      "notes": "Meeting Notes",
       "sub-menu": "TC39 Untermenü umschalten"
     },
     "specs": {

--- a/en/site.json
+++ b/en/site.json
@@ -4,8 +4,8 @@
   "navigation": {
     "TC39": {
       "title": "TC39",
-      "agenda": "Upcoming Agenda",
-      "notes": "Recent Meeting Notes",
+      "agenda": "Meeting Agendas",
+      "notes": "Meeting Notes",
       "sub-menu": "Toggle sub-menu for TC39"
     },
     "specs": {

--- a/fr/site.json
+++ b/fr/site.json
@@ -4,8 +4,8 @@
   "navigation": {
     "TC39": {
       "title": "TC39",
-      "agenda": "Agenda à venir",
-      "notes": "Notes de réunions récentes",
+      "agenda": "Meeting Agendas",
+      "notes": "Meeting Notes",
       "sub-menu": "Basculer le sous-menu pour TC39"
     },
     "specs": {

--- a/ja/site.json
+++ b/ja/site.json
@@ -4,8 +4,8 @@
   "navigation": {
     "TC39": {
       "title": "TC39",
-      "agenda": "今後の議題",
-      "notes": "直近の議事録",
+      "agenda": "Meeting Agendas",
+      "notes": "Meeting Notes",
       "sub-menu": "TC39のサブメニューを表示する"
     },
     "specs": {

--- a/ru/site.json
+++ b/ru/site.json
@@ -4,8 +4,8 @@
   "navigation": {
     "TC39": {
       "title": "TC39",
-      "agenda": "Предстоящая повестка дня",
-      "notes": "Протокол последнего собрания",
+      "agenda": "Meeting Agendas",
+      "notes": "Meeting Notes",
       "sub-menu": "Открыть меню «TC39»"
     },
     "specs": {

--- a/zh-Hans/site.json
+++ b/zh-Hans/site.json
@@ -4,8 +4,8 @@
   "navigation": {
     "TC39": {
       "title": "TC39",
-      "agenda": "下一次会议的议程",
-      "notes": "历史会议记录",
+      "agenda": "Meeting Agendas",
+      "notes": "Meeting Notes",
       "sub-menu": "展开 “TC39” 的子列表"
     },
     "specs": {


### PR DESCRIPTION
## What

This PR replaces the links to the upcoming agenda and latest meeting notes  to links to the agendas list and root of the meeting notes tree.

## Why?

- The upcoming agenda is only useful/interesting for 1-2 weeks before plenary.  This means that if updated ASAP, then it will be practically useless for several weeks, and if updated late, then it will just show the old agenda until it gets updated.
- We are assuming people coming to the website will be most interested in the most recent meeting notes, which is overly presumptive.
- We lack automation for updating these links.  While I was originally coming here to update the links to the upcoming agenda and latest meeting notes, it seemed like this could be a better change overall.

## Issues

We need updated translations, but that needn't block merge.