### PR TITLE
Add Russian Translations for site.navigation.TC39.agenda site.navigation.TC39.notes

### DIFF
--- a/ru/site.json
+++ b/ru/site.json
@@ -4,8 +4,8 @@
   "navigation": {
     "TC39": {
       "title": "TC39",
-      "agenda": "Meeting Agendas",
-      "notes": "Meeting Notes",
+      "agenda": "Повестки встреч",
+      "notes": "Протоколы встреч",
       "sub-menu": "Открыть меню «TC39»"
     },
     "specs": {


### PR DESCRIPTION
Add Russian Translations for 
- `site.navigation.TC39.agenda` 
- `site.navigation.TC39.notes`

<img width="646" alt="image" src="https://github.com/tc39/tc39.github.io/assets/14944123/40a499a2-758b-4c29-ad91-7efb22ea5980">

---

- #406